### PR TITLE
feat: AIP-213 – Common components

### DIFF
--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -62,7 +62,12 @@ representations of the following concepts:
 [rpc]: https://github.com/googleapis/googleapis/tree/master/google/rpc
 <!-- prettier-ignore-end -->
 
-### General common types
+### Common types
+
+This section provides examples for the sake of illustration; it may not be
+exhaustive. The [AIP common components][] repo is canonical.
+
+#### General common types
 
 - [`Color`][color]: RGB or RGBA colors.
 
@@ -88,7 +93,7 @@ representations of the following concepts:
 [quaternion]: https://github.com/aip-dev/common-components/tree/master/aip/type/quaternion
 <!-- prettier-ignore-end -->
 
-### Date- and time-related types
+#### Date- and time-related types
 
 - [`Date`][date]: A calendar date, with no time or time zone component.
 
@@ -119,7 +124,7 @@ representations of the following concepts:
 [timestamp]: https://github.com/aip-dev/common-components/tree/master/aip/type/timestamp
 <!-- prettier-ignore-end -->
 
-### Protobuf types
+#### Protobuf types
 
 The [`google.protobuf`][protobuf] package is shipped with protocol buffers
 itself, rather than with API tooling. The Well-Known Types defined in this

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -7,8 +7,12 @@ changes or even lead to dependency conflicts.
 
 However, there are also cases where common structures are valuable, especially
 where a concept is well-known and it is sufficiently clear that it will not
-change. Common components serve this use case. This AIP defines those common
-components.
+change. Having a single representation of these common structures is valuable
+because it avoids disrepancies between APIs in things like how dates or
+monetary values are represented. It also enables shared libraries for common
+operations, such as basic arithmetic on monetary values.
+
+Common components serve this use case.
 
 ## Guidance
 
@@ -129,12 +133,11 @@ representations of the following concepts:
 
 ### Protobuf types
 
-The [`google.protobuf`][protobuf] package is
-shipped with protocol buffers itself, rather than with API tooling. The
-Well-Known Types defined in this package should always be used when
-appropriate, and the [AIP common components][] repo does not define any
-protos for these types, even when it defines a corresponding JSON Schema. These
-include:
+The [`google.protobuf`][protobuf] package is shipped with protocol buffers
+itself, rather than with API tooling. The Well-Known Types defined in this
+package should always be used when appropriate, and the [AIP common
+components][] repo does not define any protos for these types, even when it
+defines a corresponding JSON Schema. These include:
 
 - [`google.protobuf.Duration`][duration]: Durations, with nanosecond-level
   precision. The protobuf runtime provides helper functions to convert to and

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -154,7 +154,8 @@ components][] repo), namely:
   JSON.
 
 `google.protobuf.Struct` and `google.protobuf.Value` are designated common
-components by this AIP; proto-based APIs **should** use them when appropriate.
+components by this AIP; proto-based APIs **should** use them when representing
+arbitrary JSON-like structures.
 
 <!-- prettier-ignore-start -->
 [datetime]: https://docs.python.org/3/library/datetime.html#datetime.datetime

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -158,9 +158,9 @@ However, some general guidelines are worth noting for this:
 
 - Schemas **should** only be granted common component status if it is certain
   that they will never change (at all -- even in ways that would normally be
-  considered backwards compatible). Common components are generally not
-  versioned, and it must be the case that we can rely on the component to be a
-  complete and accurate representation indefinitely.
+  considered backwards compatible). Common components are not versioned, and it
+  must be the case that API creators and consumers can rely on the component to
+  be a complete and accurate representation indefinitely.
 - Schemas must be applicable to a significant number of APIs for consideration
   as common components.
 - Even after a common component is added, APIs using local versions **must**

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -59,38 +59,60 @@ the following concepts:
 
 ### General common types
 
-- `Color`: RGB or RGBA colors.
+- [`Color`][color]: RGB or RGBA colors.
 
-- `Fraction`: A numeric fraction.
+- [`Fraction`][fraction]: A numeric fraction.
 
-- `LatLng`: Geographic coordinates.
+- [`LatLng`][lat_lng]: Geographic coordinates.
 
-- `Money`: An amount of money in a given currency.
+- [`Money`][money]: An amount of money in a given currency.
 
-- `PhoneNumber`: A phone number in most countries.
+- [`PhoneNumber`][phone_number]: A phone number in most countries.
 
-- `PostalAddress`: Postal addresses in most countries.
+- [`PostalAddress`][postal_address]: Postal addresses in most countries.
 
-- `Quaternion`: A geometric quaternion.
+- [`Quaternion`][quaternion]: A geometric quaternion.
+
+<!-- prettier-ignore-start -->
+[color]: https://github.com/aip-dev/type/tree/master/color
+[fraction]: https://github.com/aip-dev/type/tree/master/fraction
+[lat_lng]: https://github.com/aip-dev/type/tree/master/lat_lng
+[money]: https://github.com/aip-dev/type/tree/master/money
+[phone_number]: https://github.com/aip-dev/type/tree/master/phone_number
+[postal_address]: https://github.com/aip-dev/type/tree/master/postal_address
+[quaternion]: https://github.com/aip-dev/type/tree/master/quaternion
+<!-- prettier-ignore-end -->
 
 ### Date- and time-related types
 
-- `Date`: A calendar date, with no time or time zone component.
+- [`Date`][date]: A calendar date, with no time or time zone component.
 
-- `DateTime`: A calendar date and wall-clock time, with optional time zone or
-  UTC offset information.
+- [`DateTime`][date_time]: A calendar date and wall-clock time, with optional
+  time zone or UTC offset information.
 
-- `DayOfWeek`: An enumeration representing the day of the week.
+- [`DayOfWeek`][day_of_week]: An enumeration representing the day of the week.
 
-- `Duration`: A duration with nanosecond-level precision.
+- [`Duration`][duration]: A duration with nanosecond-level precision.
 
-- `Interval`: An interval between two timestamps.
+- [`Interval`][interval]: An interval between two timestamps.
 
-- `Month`: An enumeration representing the Gregorian month.
+- [`Month`][month]: An enumeration representing the Gregorian month.
 
-- `TimeOfDay`: Wall-clock time, with no date or time zone component.
+- [`TimeOfDay`][time_of_day]: Wall-clock time, with no date or time zone
+  component.
 
-- `Timestamp`: A timestamp with nanosecond-level precision.
+- [`Timestamp`][timestamp]: A timestamp with nanosecond-level precision.
+
+<!-- prettier-ignore-start -->
+[date]: https://github.com/aip-dev/type/tree/master/date
+[date_time]: https://github.com/aip-dev/type/tree/master/date_time
+[day_of_week]: https://github.com/aip-dev/type/tree/master/day_of_week
+[duration]: https://github.com/aip-dev/type/tree/master/duration
+[interval]: https://github.com/aip-dev/type/tree/master/interval
+[month]: https://github.com/aip-dev/type/tree/master/month
+[time_of_day]: https://github.com/aip-dev/type/tree/master/time_of_day
+[timestamp]: https://github.com/aip-dev/type/tree/master/timestamp
+<!-- prettier-ignore-end -->
 
 ### Protobuf types
 

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -166,9 +166,6 @@ However, some general guidelines are worth noting for this:
 - Even after a common component is added, APIs using local versions **must**
   continue to do so until they go to the next major version.
 
-In the event that you believe adding a common component is appropriate, please
-[open an issue][].
-
 <!-- prettier-ignore-start -->
 [api]: https://github.com/googleapis/googleapis/tree/master/google/api
 [rpc]: https://github.com/googleapis/googleapis/tree/master/google/rpc

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -29,18 +29,6 @@ languages that compile protobuf messages into classes.
 An API **should not** define alternative representations of any of the existing
 common components described below, even within its versioning structure.
 
-### Extending common components
-
-An API **may** define extensions of the common components, and these **may**
-have a different namespace/package name. These extensions **must** be both
-semantically and wire-compatible with the existing common components for all
-relevant transport mechanisms (gRPC, JSON, ...), but may contain additional
-fields (as long as this doesn't break semantic or wire-compatibility).
-
-For example, Google **may** use `google.type.Money` in place of
-`aip.type.Money`, but `google.type.Money` **must** have all the same fields as
-`aip.type.Money`, with identical tag numbers and equivalent documentation.
-
 ## Existing common components
 
 The common components, which public-facing APIs **may** safely depend on, are

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -129,7 +129,7 @@ representations of the following concepts:
 
 ### Protobuf types
 
-The [`google.protobuf`][protobuf] package is somewhat special in that it is
+The [`google.protobuf`][protobuf] package is
 shipped with protocol buffers itself, rather than with API tooling. The
 Well-Known Types defined in this package should always be used when
 appropriate, and the [AIP common components][] repo **does not** define any

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -20,24 +20,37 @@ any API.
 An API **must not** define a set of API-specific common components which live
 outside of its versioning structure. This prevents independent movement of
 particular versions and also causes problems for client libraries in many
-languages that compile the proto messages into classes.
+languages that compile protobuf messages into classes.
 
 An API **should not** define alternative representations of any of the existing
 common components described below, even within its versioning structure.
 
+### Extending common components
+
+An API **may** define extensions of the common components, and these **may**
+have a different namespace/package name. These extensions **must** be both
+semantically and wire-compatible with the existing common components for all
+relevant transport mechanisms (gRPC, JSON, ...), but may contain additional
+fields (as long as this doesn't break semantic or wire-compatibility).
+
+For example, Google **may** use `google.type.Money` in place of
+`aip.type.Money`, but `google.type.Money` **must** have all the same fields as
+`aip.type.Money`, with identical tag numbers and equivalent documentation.
+
 ## Existing common components
 
 The common components, which public-facing APIs **may** safely depend on, are
-defined canonically in the [AIP type][] repository. These include READMEs with
-guidance for each type, and -- when applicable -- definitions of type schemas,
-in both JSON Schema and protobuf formats. The protobufs are also published to
-the Buf Schema Sepository at [`buf.build/aip/type`][buf], and the JSON schemas
-are published to the [JSON Schema Store][] with names of the form
-`aip-type-money`.
+defined canonically in the [AIP common components][] repository. These include
+READMEs with canonical definitions for each component, and -- when applicable
+-- implementations of these definitions, in both JSON Schema and protobuf
+formats. The protobufs are also published to the Buf Schema Sepository at
+[`buf.build/aip/common`][buf], and the JSON schemas are published to the [JSON
+Schema Store][] with names beginning with `aip-`, for example `aip-type-money`
+or `aip-longrunning-operation`.
 
-While the [AIP type][] repository is canonical and has precedence over this
-list, some of the common components defined there include representations of
-the following concepts:
+While the [AIP common components][] repository is canonical and takes
+precedence over this list, some of the common components defined there include
+representations of the following concepts:
 
 ### API design patterns
 
@@ -74,13 +87,13 @@ the following concepts:
 - [`Quaternion`][quaternion]: A geometric quaternion.
 
 <!-- prettier-ignore-start -->
-[color]: https://github.com/aip-dev/type/tree/master/color
-[fraction]: https://github.com/aip-dev/type/tree/master/fraction
-[lat_lng]: https://github.com/aip-dev/type/tree/master/lat_lng
-[money]: https://github.com/aip-dev/type/tree/master/money
-[phone_number]: https://github.com/aip-dev/type/tree/master/phone_number
-[postal_address]: https://github.com/aip-dev/type/tree/master/postal_address
-[quaternion]: https://github.com/aip-dev/type/tree/master/quaternion
+[color]: https://github.com/aip-dev/common-components/tree/master/aip/type/color
+[fraction]: https://github.com/aip-dev/common-components/tree/master/aip/type/fraction
+[lat_lng]: https://github.com/aip-dev/common-components/tree/master/aip/type/lat_lng
+[money]: https://github.com/aip-dev/common-components/tree/master/aip/type/money
+[phone_number]: https://github.com/aip-dev/common-components/tree/master/aip/type/phone_number
+[postal_address]: https://github.com/aip-dev/common-components/tree/master/aip/type/postal_address
+[quaternion]: https://github.com/aip-dev/common-components/tree/master/aip/type/quaternion
 <!-- prettier-ignore-end -->
 
 ### Date- and time-related types
@@ -104,14 +117,14 @@ the following concepts:
 - [`Timestamp`][timestamp]: A timestamp with nanosecond-level precision.
 
 <!-- prettier-ignore-start -->
-[date]: https://github.com/aip-dev/type/tree/master/date
-[date_time]: https://github.com/aip-dev/type/tree/master/date_time
-[day_of_week]: https://github.com/aip-dev/type/tree/master/day_of_week
-[duration]: https://github.com/aip-dev/type/tree/master/duration
-[interval]: https://github.com/aip-dev/type/tree/master/interval
-[month]: https://github.com/aip-dev/type/tree/master/month
-[time_of_day]: https://github.com/aip-dev/type/tree/master/time_of_day
-[timestamp]: https://github.com/aip-dev/type/tree/master/timestamp
+[date]: https://github.com/aip-dev/common-components/tree/master/aip/type/date
+[date_time]: https://github.com/aip-dev/common-components/tree/master/aip/type/date_time
+[day_of_week]: https://github.com/aip-dev/common-components/tree/master/aip/type/day_of_week
+[duration]: https://github.com/aip-dev/common-components/tree/master/aip/type/duration
+[interval]: https://github.com/aip-dev/common-components/tree/master/aip/type/interval
+[month]: https://github.com/aip-dev/common-components/tree/master/aip/type/month
+[time_of_day]: https://github.com/aip-dev/common-components/tree/master/aip/type/time_of_day
+[timestamp]: https://github.com/aip-dev/common-components/tree/master/aip/type/timestamp
 <!-- prettier-ignore-end -->
 
 ### Protobuf types
@@ -119,8 +132,9 @@ the following concepts:
 The [`google.protobuf`][protobuf] package is somewhat special in that it is
 shipped with protocol buffers itself, rather than with API tooling. The
 Well-Known Types defined in this package should always be used when
-appropriate, and the [AIP type][] repo **does not** define any protos for these
-types, even when it defines a corresponding JSON Schema. These include:
+appropriate, and the [AIP common components][] repo **does not** define any
+protos for these types, even when it defines a corresponding JSON Schema. These
+include:
 
 - [`google.protobuf.Duration`][duration]: Durations, with nanosecond-level
   precision. The protobuf runtime provides helper functions to convert to and
@@ -132,8 +146,8 @@ types, even when it defines a corresponding JSON Schema. These include:
   [`datetime`][datetime]).
 
 `google.protobuf` also provides some useful components that correspond to JSON
-primitives (and so have no representation at all in the [AIP type][] repo),
-namely:
+primitives (and so have no representation at all in the [AIP common
+components][] repo), namely:
 
 - [`google.protobuf.Value`][struct]: An arbitrary JSON value. The protobuf
   runtime provides helper functions in most languages to convert `Value`
@@ -155,11 +169,28 @@ components by this AIP; proto-based APIs **should** use them when appropriate.
 [timestamp]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/timestamp.proto
 <!-- prettier-ignore-end -->
 
+## Libraries for common types
+
+For the common components in the `aip.type` namespace, which represent common
+data types, the [AIP common components][] repo may contain canonical libraries
+in a number of languages. These libraries are designed to be idiomatic in a
+given language, and should feel similar to using the language's standard
+libraries. They should provide basic functionality like adding two `Money`
+values, or determining if one `Date` comes before another.
+
+When a language already has a standard library representation of a common type
+(such as Python's `datetime` for the `Timestamp` type), there may instead be a
+library for converting the JSON or protobuf representation to the standard
+library representation.
+
+If a library you want does not exist, and you want to contribute one, please
+[open an issue][] on the [AIP common components][] repository in GitHub.
+
 ## Appendix: Adding to common components
 
 Occasionally, it may be useful to add protos to these packages or to add to the
 list of common components. In order to do this, [open an issue][] on the [AIP
-type][] repository in GitHub.
+common components][] repository in GitHub.
 
 However, some general guidelines are worth noting for this:
 
@@ -176,8 +207,8 @@ However, some general guidelines are worth noting for this:
 In the event that you believe adding a common component is appropriate, please
 [open an issue][].
 
-[open an issue]: https://github.com/aip-dev/type/issues
-[aip type]: https://github.com/aip-dev/type
+[open an issue]: https://github.com/aip-dev/common-components/issues
+[aip common components]: https://github.com/aip-dev/common-components
 [json schema store]: https://www.schemastore.org/json/
 [aip-151]: ../0151
 [buf]: https://buf.build/aip/type

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -57,11 +57,6 @@ representations of the following concepts:
 - [`google.rpc.*`][rpc]: A small number of components related to gRPC
   request/response status and errors.
 
-<!-- prettier-ignore-start -->
-[api]: https://github.com/googleapis/googleapis/tree/master/google/api
-[rpc]: https://github.com/googleapis/googleapis/tree/master/google/rpc
-<!-- prettier-ignore-end -->
-
 ### Common types
 
 This section provides examples for the sake of illustration; it may not be
@@ -83,16 +78,6 @@ exhaustive. The [AIP common components][] repo is canonical.
 
 - [`Quaternion`][quaternion]: A geometric quaternion.
 
-<!-- prettier-ignore-start -->
-[color]: https://github.com/aip-dev/common-components/tree/master/aip/type/color
-[fraction]: https://github.com/aip-dev/common-components/tree/master/aip/type/fraction
-[lat_lng]: https://github.com/aip-dev/common-components/tree/master/aip/type/lat_lng
-[money]: https://github.com/aip-dev/common-components/tree/master/aip/type/money
-[phone_number]: https://github.com/aip-dev/common-components/tree/master/aip/type/phone_number
-[postal_address]: https://github.com/aip-dev/common-components/tree/master/aip/type/postal_address
-[quaternion]: https://github.com/aip-dev/common-components/tree/master/aip/type/quaternion
-<!-- prettier-ignore-end -->
-
 #### Date- and time-related types
 
 - [`Date`][date]: A calendar date, with no time or time zone component.
@@ -112,17 +97,6 @@ exhaustive. The [AIP common components][] repo is canonical.
   component.
 
 - [`Timestamp`][timestamp]: A timestamp with nanosecond-level precision.
-
-<!-- prettier-ignore-start -->
-[date]: https://github.com/aip-dev/common-components/tree/master/aip/type/date
-[date_time]: https://github.com/aip-dev/common-components/tree/master/aip/type/date_time
-[day_of_week]: https://github.com/aip-dev/common-components/tree/master/aip/type/day_of_week
-[duration]: https://github.com/aip-dev/common-components/tree/master/aip/type/duration
-[interval]: https://github.com/aip-dev/common-components/tree/master/aip/type/interval
-[month]: https://github.com/aip-dev/common-components/tree/master/aip/type/month
-[time_of_day]: https://github.com/aip-dev/common-components/tree/master/aip/type/time_of_day
-[timestamp]: https://github.com/aip-dev/common-components/tree/master/aip/type/timestamp
-<!-- prettier-ignore-end -->
 
 #### Protobuf types
 
@@ -156,15 +130,6 @@ components][] repo), namely:
 `google.protobuf.Struct` and `google.protobuf.Value` are designated common
 components by this AIP; proto-based APIs **should** use them when representing
 arbitrary JSON-like structures.
-
-<!-- prettier-ignore-start -->
-[datetime]: https://docs.python.org/3/library/datetime.html#datetime.datetime
-[duration]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/duration.proto
-[protobuf]: https://github.com/protocolbuffers/protobuf/tree/main/src/google/protobuf
-[struct]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/struct.proto
-[timedelta]: https://docs.python.org/3/library/datetime.html#datetime.timedelta
-[timestamp]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/timestamp.proto
-<!-- prettier-ignore-end -->
 
 ## Libraries for common types
 
@@ -204,8 +169,37 @@ However, some general guidelines are worth noting for this:
 In the event that you believe adding a common component is appropriate, please
 [open an issue][].
 
+<!-- prettier-ignore-start -->
+[api]: https://github.com/googleapis/googleapis/tree/master/google/api
+[rpc]: https://github.com/googleapis/googleapis/tree/master/google/rpc
+
+[color]: https://github.com/aip-dev/common-components/tree/master/aip/type/color
+[fraction]: https://github.com/aip-dev/common-components/tree/master/aip/type/fraction
+[lat_lng]: https://github.com/aip-dev/common-components/tree/master/aip/type/lat_lng
+[money]: https://github.com/aip-dev/common-components/tree/master/aip/type/money
+[phone_number]: https://github.com/aip-dev/common-components/tree/master/aip/type/phone_number
+[postal_address]: https://github.com/aip-dev/common-components/tree/master/aip/type/postal_address
+[quaternion]: https://github.com/aip-dev/common-components/tree/master/aip/type/quaternion
+
+[date]: https://github.com/aip-dev/common-components/tree/master/aip/type/date
+[date_time]: https://github.com/aip-dev/common-components/tree/master/aip/type/date_time
+[day_of_week]: https://github.com/aip-dev/common-components/tree/master/aip/type/day_of_week
+[duration]: https://github.com/aip-dev/common-components/tree/master/aip/type/duration
+[interval]: https://github.com/aip-dev/common-components/tree/master/aip/type/interval
+[month]: https://github.com/aip-dev/common-components/tree/master/aip/type/month
+[time_of_day]: https://github.com/aip-dev/common-components/tree/master/aip/type/time_of_day
+[timestamp]: https://github.com/aip-dev/common-components/tree/master/aip/type/timestamp
+
+[datetime]: https://docs.python.org/3/library/datetime.html#datetime.datetime
+[duration]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/duration.proto
+[protobuf]: https://github.com/protocolbuffers/protobuf/tree/main/src/google/protobuf
+[struct]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/struct.proto
+[timedelta]: https://docs.python.org/3/library/datetime.html#datetime.timedelta
+[timestamp]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/timestamp.proto
+
 [open an issue]: https://github.com/aip-dev/common-components/issues
 [aip common components]: https://github.com/aip-dev/common-components
 [json schema store]: https://www.schemastore.org/json/
 [aip-151]: ../0151
 [buf]: https://buf.build/aip/type
+<!-- prettier-ignore-end -->

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -1,0 +1,158 @@
+# Unicode
+
+APIs should be consistent on how they explain, limit, and bill for string
+values and their encodings. This ranges from little ambiguities (like fields
+"limited to 1024 characters") all the way to billing confusion (are names and
+values of properties in Datastore billed based on characters or bytes?).
+
+In general, if limits are measured in bytes, we are discriminating against
+non-ASCII text since it takes up more space. On the other hand, if limits are
+measured in "characters", this is ambiguous about whether those are Unicode
+"code points", "code units" for a particular encoding (e.g. UTF-8 or UTF-16),
+"graphemes", or "grapheme clusters".
+
+## Unicode primer
+
+Character encoding tends to be an area we often gloss over, so a quick primer:
+
+- Strings are just sequences of bytes that represent text according to some
+  encoding format.
+- When we talk about **characters**, we sometimes mean Unicode **code points**,
+  which are 21-bit unsigned integers `0` through `0x10FFFF`.
+- Other times we might mean **grapheme clusters**, which are _perceived_ as
+  single characters but may be composed of multiple code points. For example,
+  `á` can be represented as the single code point `U+00E1` or as a sequence of
+  `U+0061` followed by `U+0301` (the letter `a`, then a combining acute
+  accent).
+- Protocol buffers uses **UTF-8** ("Unicode Transformation Format") which is a
+  variable-length encoding scheme that represents each code point as a sequence
+  of 1 to 4 single-byte **code units**.
+
+## Guidance
+
+### Character definition
+
+**TL;DR:** In our APIs, "character" means "Unicode code point".
+
+In API documentation (e.g., API reference documents, blog posts, marketing
+documentation, billing explanations, etc), "character" **must** be defined as a
+Unicode code point.
+
+### Length units
+
+**TL;DR:** Set size limits in "characters" (as defined above).
+
+All string field length limits defined in the API **must** be measured and
+enforced in characters as defined above. This means that there is an underlying
+maximum limit of (`4 * characters`) bytes, though this limit will only be hit
+when using exclusively characters that consist of 4 UTF-8 code units (32 bits).
+
+If you use a database system (e.g. Spanner) which allows you to define a limit
+in characters, it is safe to assume that this byte-defined requirement is
+handled by the underlying storage system.
+
+### Billing units
+
+APIs **may** use either code points or bytes (using the UTF-8 encoding) as the
+unit for billing or quota measurement (e.g., Cloud Translation chooses to use
+characters). If an API does not define this, the assumption is that the unit of
+billing is characters (e.g., $0.01 _per character_, not $0.01 _per byte_).
+
+### Unique identifiers
+
+**TL;DR:** Unique identifiers **should** limit to ASCII, generally only
+letters, numbers, hyphens, and underscores. Additionally, unique identifiers
+**should** start with a letter, **should** end in either a letter or number,
+and **should not** have hyphens or underscores that are next to other hyphens
+or underscores.
+
+Strings used as unique identifiers **should** limit inputs to ASCII characters,
+typically letters, numbers, hyphens, and underscores
+(`[a-zA-Z][a-zA-Z0-9_-]*`). This ensures that there are never accidental
+collisions due to normalization. If an API decides to allow all valid Unicode
+characters in unique identifiers, the API **must** reject any inputs that are
+not in Normalization Form C.
+
+Unique identifiers **should** use a maximum length of 64 characters, though
+this limit may be expanded as necessary. 64 characters should be sufficient for
+most purposes as even UUIDs only require 36 characters.
+
+### Normalization
+
+**TL;DR:** Unicode values **should** be stored in [Normalization Form C][].
+
+Values **should** always be normalized into Normalization Form C. Unique
+identifiers **must** always be stored in Normalization Form C (see the next
+section).
+
+Imagine we're dealing with Spanish input "estar<strong>é</strong>" (the
+accented part will be bolded throughout). This text has 6 grapheme clusters,
+and can be represented by two distinct sequences of Unicode code points:
+
+- Using 6 code points: `U+0065` `U+0073` `U+0074` `U+0061` `U+0072`
+  **`U+00E9`**
+- Using 7 code points: `U+0065` `U+0073` `U+0074` `U+0061` `U+0072` **`U+0065`
+  `U+0301`**
+
+Further, when encoding to UTF-8, these code points have two different
+serialized representations:
+
+- Using 7 code-units (7 bytes): `0x65` `0x73` `0x74` `0x61` `0x72` **`0xC3`
+  `0xA9`**
+- Using 8 code-units (8 bytes): `0x65` `0x73` `0x74` `0x61` `0x72` **`0x65`
+  `0xCC` `0x81`**
+
+To avoid this discrepancy in size (both code units and code points), use
+[Normalization Form C][] which provides a canonical representation for strings.
+
+[normalization form c]: https://unicode.org/reports/tr15/
+
+### Uniqueness
+
+**TL;DR:** Unicode values **must** be normalized to [Normalization Form C][]
+before checking uniqueness.
+
+For the purposes of unique identification (e.g., `name`, `id`, or `parent`),
+the value **must** be normalized into [Normalization Form C][] (which happens
+to be the most compact). Otherwise we may have what is essentially "the same
+string" used to identify two entirely different resources.
+
+In our example above, there are two ways of representing what is essentially
+the same text. This raises the question about whether the two representations
+should be treated as equivalent or not. In other words, if someone were to use
+both of those byte sequences in a string field that acts as a unique
+identifier, would it violate a uniqueness constraint?
+
+The W3C recommends using Normalization Form C for all content moving across the
+internet. It is the most compact normalized form on Unicode text, and avoids
+most interoperability problems. If we were to treat two Unicode byte sequences
+as different when they have the same representation in NFC, we'd be required to
+reply to possible "Get" requests with content that is **not** in normalized
+form. Since that is definitely unacceptable, we **must** treat the two as
+identical by transforming any incoming string data into Normalized Form C or
+rejecting identifiers not in the normalized form.
+
+There is some debate about whether we should view strings as sequences of code
+points encoded into byte sequences (leading to uniqueness determined based on
+the byte-representation of said string) or to interpret strings as a higher
+level abstraction having many different possible byte-representations. The
+stance taken here is that we already have a field type for handling that:
+`bytes`. Fields of type `string` already express an opinion of the validity of
+an input (it must be valid UTF-8). As a result, treating two inputs that have
+identical normalized forms as different due to their underlying byte
+representation seems to go against the original intent of the `string` type.
+This distinction typically doesn't matter for strings that are opaque to our
+services (e.g., `description` or `display_name`), however when we rely on
+strings to uniquely identify resources, we are forced to take a stance.
+
+Put differently, our goal is to allow someone with text in any encoding (ASCII,
+UTF-16, UTF-32, etc) to interact with our APIs without a lot of "gotchas".
+
+## References
+
+- [Unicode normalization forms](https://unicode.org/reports/tr15/)
+- [Datastore pricing "name and value of each property"](https://cloud.google.com/datastore/pricing)
+  doesn't clarify this.
+- [Natural Language pricing](https://cloud.google.com/natural-language/pricing)
+  uses charges based on UTF-8 code points rather than code units.
+- [Text matching and normalization](https://sites.google.com/a/google.com/intl-eng/apis/matching?pli=1)

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -156,7 +156,7 @@ common components][] repository in GitHub.
 
 However, some general guidelines are worth noting for this:
 
-- Schemas **should** only be granted common component status if we are certain
+- Schemas **should** only be granted common component status if it is certain
   that they will never change (at all -- even in ways that would normally be
   considered backwards compatible). Common components are generally not
   versioned, and it must be the case that we can rely on the component to be a

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -132,7 +132,7 @@ representations of the following concepts:
 The [`google.protobuf`][protobuf] package is
 shipped with protocol buffers itself, rather than with API tooling. The
 Well-Known Types defined in this package should always be used when
-appropriate, and the [AIP common components][] repo **does not** define any
+appropriate, and the [AIP common components][] repo does not define any
 protos for these types, even when it defines a corresponding JSON Schema. These
 include:
 

--- a/aip/general/0213/aip.md
+++ b/aip/general/0213/aip.md
@@ -28,11 +28,12 @@ common components described below, even within its versioning structure.
 ## Existing common components
 
 The common components, which public-facing APIs **may** safely depend on, are
-defined canonically in the [AIP type][] repository. These include definitions
-of common type schemas, in both JSON Schema and protobuf formats. The protobufs
-are also published to the Buf Schema Sepository at [`buf.build/aip/type`][buf],
-and the JSON schemas are published to the [JSON Schema Store][] with names of
-the form `aip-type-money`.
+defined canonically in the [AIP type][] repository. These include READMEs with
+guidance for each type, and -- when applicable -- definitions of type schemas,
+in both JSON Schema and protobuf formats. The protobufs are also published to
+the Buf Schema Sepository at [`buf.build/aip/type`][buf], and the JSON schemas
+are published to the [JSON Schema Store][] with names of the form
+`aip-type-money`.
 
 While the [AIP type][] repository is canonical and has precedence over this
 list, some of the common components defined there include representations of

--- a/aip/general/0213/aip.yaml
+++ b/aip/general/0213/aip.yaml
@@ -1,0 +1,7 @@
+---
+id: 213
+state: draft
+created: 2022-09-13
+placement:
+  category: resource-design
+  order: 120


### PR DESCRIPTION
(Note: this PR has an initial commit containing google.aip.dev's AIP-213 without modification.  Comparing this to subsequent commits will make it easier to see what was changed.)

# Summary

This PR adapts Google's AIP-213.  On top of substantial rewording/refactoring/de-Googling, this AIP also proposes the following new details (none of which are implemented yet):

* A new repo at github.com/aip-dev/type.  This repo is similar in spirit to google.type, except that for each type it includes a README containing guidance, and -- when applicable -- corresponding protobuf and JSON Schema definitions.
* The JSON schemas in that repo would be published to https://schemastore.org.
* The protos in that repo would be published on the [Buf](https://buf.build) Schema Repository at `buf.build/aip/type` (I grabbed buf.build/aip tonight, so we can use it).

Regarding the type repo, I imagine top-level directories for each type (maybe some of the datetime-related types go together), with each directory containing a README, a proto (when applicable), and a JSON Schema.

## Alternative

Another way to write this would be as a series of AIPs, one focused on each type, rather than having some guidance living in the type repo.  I think it's better to keep the type guidance with the type definitions, rather than trying to keep all the AIP guidance in the `aip-dev/aip-dev` repo (it's all within the `aip-dev` org anyway), but interested in other opinions.

## Practical note

I really wish this already existed, because it'd be useful to Roblox right now, saving me the trouble of doing stuff that I think is worse. :)  I expect it'll be useful to us one day, and hopefully in a year it'll be useful to whoever's a year behind us in terms of adoption.