### PR TITLE
Adding maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,25 @@
+# AIP Maintainers
+
+This page lists all active maintainers of the aip.dev and standard. Maintainers have write and approval privileges to the aip.dev repository.
+
+## Maintainers
+
+| Name                                                | GitHub                                           | Organization (if applicable) |
+| --------------------------------------------------- | ------------------------------------------------ | ---------------------------- |
+| [Yusuke Tsutsumi](mailto:yusuketsutsumi@google.com) | [@toumorokoshi](https://github.com/toumorokoshi) | Google                       |
+| [Mak Ahmad](mailto:mak1@fb.com)                     | [@makahmad](https://github.com/makahmad)         | Meta                         |
+| Richard Frankle                                     | [@rofrankel](https://github.com/rofrankel)       | Roblox                       |
+| Dan Hudlow                                          | [@hudlow](https://github.com/hudlow)             | IBM                          |
+| Alfred Fuller                                       | [@alfus](https://github.com/alfus)               |                              |
+| Jeff Albert                                         | [@monkey-jeff](https://github.com/monkey-jeff)   | Salesforce                   |
+| Mike Kistler                                        | [@mkistler](https://github.com/mkistler)         | Microsoft                    |
+| Richard Gibson                                      | [@gibson042](https://github.com/gibson042)       | Algoric                      |
+| [David Ebbo](mailto:davidebbo@google.com)           | [@davidebbo](https://github.com/davidebbo)       | Google                       |
+| [Sam Woodard](mailto:samwoodard@google.com)         | [@shwoodard](https://github.com/shwoodard)       | Google                       |
+
+## Emiritus
+
+The following table enumerates previous maintainers of the aip.dev standard.
+
+| Name | GitHub | Organization (if applicable) |
+| ---- | ------ | ---------------------------- |


### PR DESCRIPTION
Adding a list of public maintainers to the AIPs,
to help showcase the variety of contributing organizations to the AIPs and clarify contacts on PRs.

fixes #106