### PR TITLE
chore: updated codeowners

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -8,7 +8,7 @@ This page lists all active maintainers of the aip.dev and standard. Maintainers 
 | --------------------------------------------------- | ------------------------------------------------ | ---------------------------- |
 | [Yusuke Tsutsumi](mailto:yusuketsutsumi@google.com) | [@toumorokoshi](https://github.com/toumorokoshi) | Google                       |
 | [Mak Ahmad](mailto:mak1@fb.com)                     | [@makahmad](https://github.com/makahmad)         | Meta                         |
-| Richard Frankle                                     | [@rofrankel](https://github.com/rofrankel)       | Roblox                       |
+| Richard Frankel                                     | [@rofrankel](https://github.com/rofrankel)       | Roblox                       |
 | Dan Hudlow                                          | [@hudlow](https://github.com/hudlow)             | IBM                          |
 | Alfred Fuller                                       | [@alfus](https://github.com/alfus)               |                              |
 | Jeff Albert                                         | [@monkey-jeff](https://github.com/monkey-jeff)   | Salesforce                   |
@@ -16,10 +16,12 @@ This page lists all active maintainers of the aip.dev and standard. Maintainers 
 | Richard Gibson                                      | [@gibson042](https://github.com/gibson042)       | Algoric                      |
 | [David Ebbo](mailto:davidebbo@google.com)           | [@davidebbo](https://github.com/davidebbo)       | Google                       |
 | [Sam Woodard](mailto:samwoodard@google.com)         | [@shwoodard](https://github.com/shwoodard)       | Google                       |
+| JJ Geewax                                           | [@jgeewax](https://github.com/jgeewax)           | Meta                         |
 
 ## Emiritus
 
 The following table enumerates previous maintainers of the aip.dev standard.
 
-| Name | GitHub | Organization (if applicable) |
-| ---- | ------ | ---------------------------- |
+| Name            | GitHub                                               | Organization (if applicable) |
+| --------------- | ---------------------------------------------------- | ---------------------------- |
+| Luke Sneeringer | [@lukesneeringer](https://github.com/lukesneeringer) |                              |


### PR DESCRIPTION
Fixing a typo, and adding additional codeowners and emiritus.